### PR TITLE
Add missing screen name parameter

### DIFF
--- a/Sources/AnalyticsProivder/GXFirebaseAnalyticsService.swift
+++ b/Sources/AnalyticsProivder/GXFirebaseAnalyticsService.swift
@@ -64,6 +64,7 @@ extension GXFirebaseAnalyticsService: GXAnalyticsService {
 	public func trackView(_ name: String) {
 		#if os(iOS)
 		Analytics.logEvent(AnalyticsEventScreenView, parameters: [
+			AnalyticsParameterScreenName: name,
 			AnalyticsParameterScreenClass: "gx_view"
 		])
 		#else


### PR DESCRIPTION
This PR adds missing `AnalyticsParameterScreenName` parameter to the `GXAnalyticsService.trackView(_:)` method implementation.

Reference documentation: https://firebase.google.com/docs/analytics/screenviews?hl=es-419#manually_track_screens