### PR TITLE
Convert "items" parameter to an array of dictionaries for Firebase Analytics

### DIFF
--- a/Sources/AnalyticsProivder/GXFirebaseAnalyticsService.swift
+++ b/Sources/AnalyticsProivder/GXFirebaseAnalyticsService.swift
@@ -92,6 +92,14 @@ extension GXFirebaseAnalyticsService: GXAnalyticsService {
 		if let customParameters {
 			parameters.merge(customParameters) { (_, second) in second }
 		}
+        
+        // Send the special "items" item as an array of dictionaries instead of a string
+		// Ref: https://firebase.google.com/docs/reference/kotlin/com/google/firebase/analytics/FirebaseAnalytics.Param#ITEMS()
+        if let itemsString = parameters[AnalyticsParameterItems] as? String,
+           let itemsData = itemsString.data(using: .utf8),
+           let itemsDict = try? JSONSerialization.jsonObject(with: itemsData, options: []) as? [[String: Any]] {
+            parameters[AnalyticsParameterItems] = itemsDict
+        }
 		
 		Analytics.logEvent(eventName, parameters: parameters)
 #else


### PR DESCRIPTION
This pull request updates the `GXFirebaseAnalyticsService` to improve how the "items" parameter is handled when sending analytics events to Firebase. The change **ensures that the "items" parameter is sent as an array of dictionaries instead of a string**, as required by Firebase.

### Key Change:
* [`Sources/AnalyticsProvider/GXFirebaseAnalyticsService.swift`](diffhunk://#diff-9d838ab261ceb53ad35f4f8e3cdcbfa0757ce1ac24a6a780380623e093bb710aR96-R103): Updated the handling of the `AnalyticsParameterItems` parameter, if present, to parse a JSON string into an array of dictionaries before sending it to Firebase.

Issue: [204539](https://issues.genexus.dev/viewissue.aspx?204539)